### PR TITLE
Handle arbitrary number of escaped chars within string

### DIFF
--- a/plyara/interp.py
+++ b/plyara/interp.py
@@ -310,8 +310,7 @@ def t_SECTIONCONDITION(t):
   return t
 
 def t_STRING(t):
-  #r'".+?"(?<![^\\]\\")'
-  r'".*?"(?<![^\\]\\")(?<![^\\][\\]{3}")(?<![^\\][\\]{5}")'
+  r"(?P<openingQuote>[\"'])(?:(?=(?P<escaped>\\?))(?P=escaped).)*?(?P=openingQuote)"
   t.value = t.value
   return t
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 setup(
     name             =   "Plyara",
     packages         =   ['plyara'],
-    version          =   '0.1.1',
+    version          =   '0.1.2',
     description      =   'Parse Yara Rules',
     install_requires =   ['ply>=3.7']
 )


### PR DESCRIPTION
Handle arbitrary number of escaped strings

```
$a = "something\\\""
$b = "something\\\\\""
$c = "something\\\\\\\""
```