### PR TITLE
Adds ability to track raw sections in plyara, and fixes multi handler…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,14 +10,14 @@ here = path.abspath(path.dirname(__file__))
 with open(path.join(here, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
-install_requires = ['ply']
+install_requires = ['ply>=3.11']
 if sys.version_info < (3, ):
     install_requires.append('enum34')
 
 setup(
     name='plyara',
 
-    version='1.1.0',
+    version='1.1.1',
 
     description='Parse Yara Rules',
     long_description=long_description,

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -145,6 +145,90 @@ class TestYaraRules(unittest.TestCase):
         self.assertTrue('"lib1"' in rule['imports'] and '"lib2"' in rule['imports'])
         self.assertTrue('global' in rule['scopes'] and 'private' in rule['scopes'])
 
+  def test_rule_name(self):
+
+    inputRule = r'''
+
+    rule testName
+    {
+    meta:
+    my_identifier_1 = ""
+    my_identifier_2 = 24
+    my_identifier_3 = true
+
+    strings:
+        $my_text_string = "text here"
+        $my_hex_string = { E2 34 A1 C8 23 FB }
+
+    condition:
+        $my_text_string or $my_hex_string
+    }
+
+    '''
+
+    plyara = Plyara()
+    result = plyara.parse_string(inputRule)
+
+    self.assertTrue(len(result) == 1)
+    self.assertTrue(result[0]['rule_name'] == "testName")
+
+  def test_store_raw(self):
+
+    inputRule = r'''
+
+    rule testName
+    {
+    meta:
+    my_identifier_1 = ""
+    my_identifier_2 = 24
+    my_identifier_3 = true
+
+    strings:
+        $my_text_string = "text here"
+        $my_hex_string = { E2 34 A1 C8 23 FB }
+
+    condition:
+        $my_text_string or $my_hex_string
+    }
+
+    rule testName2 {
+    strings:
+      $test1 = "some string"
+
+    condition:
+      $test1 or true
+    }
+
+    rule testName3 {
+
+    condition:
+      true
+    }
+
+    rule testName4 : tag1 tag2 {meta: i = "j" strings: $a = "b" condition: true }
+
+    '''
+
+    plyara = Plyara(store_raw_sections=True)
+    result = plyara.parse_string(inputRule)
+
+    self.assertTrue(len(result) == 4)
+    self.assertTrue(result[0].get("raw_meta", False))
+    self.assertTrue(result[0].get("raw_strings", False))
+    self.assertTrue(result[0].get("raw_condition", False))
+
+    self.assertFalse(result[1].get("raw_meta", False))
+    self.assertTrue(result[1].get("raw_strings", False))
+    self.assertTrue(result[1].get("raw_condition", False))
+
+    self.assertFalse(result[2].get("raw_meta", False))
+    self.assertFalse(result[2].get("raw_strings", False))
+    self.assertTrue(result[2].get("raw_condition", False))
+
+    self.assertTrue(result[3].get("raw_meta", False))
+    self.assertTrue(result[3].get("raw_strings", False))
+    self.assertTrue(result[3].get("raw_condition", False))
+
   def test_tags(self):
 
     inputTags = r'''


### PR DESCRIPTION
For one use case, I use plyara to adjust and normalize metadata fields and rule names, but want to maintain original rule body sections when converting normalized rule contents back to a usable rule. The original would maintain comment ordering, padding for rule layout, and other features often lost during the tokenization process in plyara.

Thus, by passing store_raw_sections=True when initializing, plyara will now store the raw, original input for meta, strings, and condition sections when available, for each rule.

Also fixed minor bug when initializing multiple instances of Plyara that could lead to multiple stream handlers attached.